### PR TITLE
Bump async-tungstenite version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "najamelan/ws_stream_tungstenite"
 rustc_version = "^0.2"
 
 [dependencies]
-async-tungstenite = "^0.8"
+async-tungstenite = "^0.9"
 bitflags = "^1"
 log = "^0.4"
 pharos = "^0.4"
@@ -56,7 +56,7 @@ version = "^1"
 
 [dev-dependencies.async-tungstenite]
 features = ["tokio-runtime", "async-std-runtime"]
-version = "^0.8"
+version = "^0.9"
 
 [dev-dependencies.tokio]
 default-features = false


### PR DESCRIPTION
Bump async-tungstenite version from 0.8 to 0.9, now including `tokio-rustls`. 