### PR TITLE
Update tungstenite to 0.17.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rustc_version = "^0.4"
 [dependencies]
 [dependencies.async-tungstenite]
 default-features = false
-version = "^0.16"
+version = "^0.17"
 
 [dependencies.async_io_stream]
 default-features = false
@@ -54,7 +54,7 @@ version = "^1"
 
 [dependencies.tungstenite]
 default-features = false
-version = "^0.16"
+version = "^0.17"
 
 [dev-dependencies]
 assert_matches = "^1"
@@ -74,7 +74,7 @@ version = "^1"
 
 [dev-dependencies.async-tungstenite]
 features = ["tokio-runtime", "async-std-runtime"]
-version = "^0.16"
+version = "^0.17"
 
 [dev-dependencies.tokio]
 default-features = false

--- a/src/tung_websocket.rs
+++ b/src/tung_websocket.rs
@@ -268,6 +268,11 @@ impl<S: Unpin> Stream for TungWebSocket<S> where S: AsyncRead + AsyncWrite + Sen
 						self.queue_event( WsEvent::Pong(data) );
 						self.poll_next( cx )
 					}
+
+					TungMessage::Frame(_) =>
+					{
+						unreachable!("A Message::Frame(..) should be never occur from a read")
+					}
 				}
 			}
 


### PR DESCRIPTION
This PR just updates the tungstenite dependency and fixes the code per the API changes. As noted in the `TungMessage::Frame` branch in the code below, `TungMessage::Frame` should never occur from a read but is currently only intended to be used for fragmentated writes. This is discussed [here](https://github.com/snapview/tungstenite-rs/pull/250).