### PR TITLE
Update to tungstenite 0.20, deal with max_send_buffer_len

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,27 @@
 
 ## [Unreleased]
 
-  [Unreleased]: https://github.com/najamelan/ws_stream_tungstenite/compare/0.10.0...dev
+  [Unreleased]: https://github.com/najamelan/ws_stream_tungstenite/compare/0.11.0...dev
+
+
+## [0.11.0 - 2023-10-07]
+
+  [0.11.0]: https://github.com/najamelan/ws_stream_tungstenite/compare/0.9.0...0.10.0
+  
+  - **BREAKING_CHANGE**/**SECURITY UPDATE**: update tungstenite to 0.20.1. 
+    See: [RUSTSEC-2023-0065](https://rustsec.org/advisories/RUSTSEC-2023-0065).
+    Make sure to check how the new version of tungstenite 
+    [handles buffering](https://docs.rs/tungstenite/latest/tungstenite/protocol/struct.WebSocketConfig.html) 
+    messages before sending them. Having `write_buffer_size` to anything but `0` might cause
+    messages not to be sent until you flush. _ws_stream_tungstenite_ will make sure to respect
+    `max_write_buffer_size`, so you shouldn't have to deal with the errors, but note that if
+    you set it to something really small it might lead to performance issues on throughput.
+    I wanted to roll this version out fast for the security vulnerability, but note that the 
+    implementation of `AsyncWrite::poll_write_vectored` that handles compliance with `max_write_buffer_size`
+    currently has no tests. If you want to use it, please review the code.     
+  - **BREAKING_CHANGE**: update async-tungstenite to 0.23
+  - **BREAKING_CHANGE**: switched to tracing for logging (check out the _tracing-log_ crate
+    if you need to consume the events with a log consumer)
 
 
 ## [0.10.0]
@@ -12,6 +32,7 @@
   
   - **BREAKING_CHANGE**: update async-tungstenite to 0.22
   - **BREAKING_CHANGE**: update tungstenite to 0.19
+
 
 ## [0.9.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,10 +39,6 @@ version = "^0.3"
 default-features = false
 version = "^0.3"
 
-[dependencies.log]
-default-features = false
-version = "^0.4"
-
 [dependencies.pharos]
 default-features = false
 version = "^0.5"
@@ -52,6 +48,9 @@ default-features = false
 optional = true
 version = "^1"
 
+[dependencies.tracing]
+version = "^0.1"
+
 [dependencies.tungstenite]
 default-features = false
 version = "^0.20"
@@ -60,12 +59,12 @@ version = "^0.20"
 assert_matches = "^1"
 async_progress = "^0.2"
 asynchronous-codec = "^0.6"
-flexi_logger = "^0.25"
 futures = "^0.3"
 futures-test = "^0.3"
 futures-timer = "^3"
 futures_ringbuf = "^0.3"
 pin-utils = "^0.1"
+tracing-log = "^0.1"
 url = "^2"
 
 [dev-dependencies.async-std]
@@ -85,6 +84,11 @@ version = "^1"
 default-features = false
 features = ["codec"]
 version = "^0.7"
+
+[dev-dependencies.tracing-subscriber]
+default-features = false
+features = ["ansi", "env-filter", "fmt", "json", "tracing-log"]
+version = "^0.3"
 
 [[example]]
 name = "tokio_codec"
@@ -108,7 +112,7 @@ license = "Unlicense"
 name = "ws_stream_tungstenite"
 readme = "README.md"
 repository = "https://github.com/najamelan/ws_stream_tungstenite"
-version = "0.10.0"
+version = "0.11.0"
 
 [package.metadata]
 [package.metadata.docs]

--- a/Cargo.yml
+++ b/Cargo.yml
@@ -25,7 +25,7 @@ package:
   # - `git tag x.x.x` with version number.
   # - `git push && git push --tags`
   #
-  version       : 0.10.0
+  version       : 0.11.0
   name          : ws_stream_tungstenite
   edition       : '2021'
   authors       : [ Naja Melan <najamelan@autistici.org> ]
@@ -69,11 +69,11 @@ dependencies:
   futures-sink      : { version: ^0.3 , default-features: false                 }
   futures-io        : { version: ^0.3 , default-features: false                 }
   futures-util      : { version: ^0.3 , default-features: false                 }
-  log               : { version: ^0.4 , default-features: false                 }
   tungstenite       : { version: ^0.20, default-features: false                 }
   pharos            : { version: ^0.5 , default-features: false                 }
   async-tungstenite : { version: ^0.23, default-features: false                 }
   tokio             : { version: ^1   , default-features: false, optional: true }
+  tracing           : { version: ^0.1 }
 
   # private deps
   #
@@ -87,7 +87,6 @@ dev-dependencies:
   async-tungstenite   : { version: ^0.23, features: [ tokio-runtime, async-std-runtime ] }
   assert_matches      : ^1
   async_progress      : ^0.2
-  flexi_logger        : ^0.25
   futures             : ^0.3
   futures-test        : ^0.3
   futures-timer       : ^3
@@ -96,6 +95,9 @@ dev-dependencies:
   # pretty_assertions   : ^0.6
   tokio               : { version: ^1, default-features: false, features: [ net, rt, rt-multi-thread, macros ] }
   tokio-util          : { version: ^0.7, default-features: false, features: [ codec ] }
+  tracing-subscriber  : { version: ^0.3, default-features: false, features: [ ansi, env-filter, fmt, json, tracing-log ] }
+  tracing-log         : ^0.1
+
   # tokio-stream        : { version: ^0.1, default-features: false, features: [] }
   url                 : ^2
   pin-utils           : ^0.1

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ use
 {
    ws_stream_tungstenite :: { *                  } ,
    futures               :: { StreamExt          } ,
-   log                   :: { *                  } ,
+   tracing               :: { *                  } ,
    async_tungstenite     :: { accept_async       } ,
    asynchronous_codec    :: { LinesCodec, Framed } ,
    async_std             :: { net::TcpListener   } ,

--- a/examples/close.rs
+++ b/examples/close.rs
@@ -2,31 +2,23 @@
 //
 use
 {
-	ws_stream_tungstenite  :: { *                                            } ,
+	ws_stream_tungstenite  :: { *                                                          } ,
 	futures                :: { TryFutureExt, StreamExt, SinkExt, join, executor::block_on } ,
-	asynchronous_codec     :: { LinesCodec, Framed                           } ,
-	tokio                  :: { net::{ TcpListener }                         } ,
-	futures                :: { FutureExt, select, future::{ ok, ready }     } ,
-	async_tungstenite      :: { accept_async, tokio::{ TokioAdapter, connect_async } } ,
-	url                    :: { Url                                          } ,
-	log                    :: { *                                            } ,
-	std                    :: { time::Duration                               } ,
-	futures_timer          :: { Delay                                        } ,
-	pin_utils              :: { pin_mut                                      } ,
+	asynchronous_codec     :: { LinesCodec, Framed                                         } ,
+	tokio                  :: { net::{ TcpListener }                                       } ,
+	futures                :: { FutureExt, select, future::{ ok, ready }                   } ,
+	async_tungstenite      :: { accept_async, tokio::{ TokioAdapter, connect_async }       } ,
+	url                    :: { Url                                                        } ,
+	tracing               :: { *                                                           } ,
+	std                    :: { time::Duration                                             } ,
+	futures_timer          :: { Delay                                                      } ,
+	pin_utils              :: { pin_mut                                                    } ,
 };
 
 
 
 fn main()
 {
-	flexi_logger::Logger
-
-		::try_with_str( "close=info, tungstenite=warn, tokio_tungstenite=warn, ws_stream_tungstenite=warn" )
-		.expect( "flexi_logger")
-		.start()
-		.expect( "flexi_logger")
-	;
-
 	block_on( async
 	{
 		join!( server(), client() );

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -6,7 +6,7 @@ use
 	ws_stream_tungstenite :: { *                                         } ,
 	futures               :: { AsyncReadExt, io::{ BufReader, copy_buf } } ,
 	std                   :: { env, net::SocketAddr, io                  } ,
-	log                   :: { *                                         } ,
+	tracing               :: { *                                         } ,
 	tokio                 :: { net::{ TcpListener, TcpStream }           } ,
 	async_tungstenite     :: { accept_async, tokio::{ TokioAdapter }     } ,
 };

--- a/examples/echo_tt.rs
+++ b/examples/echo_tt.rs
@@ -7,7 +7,7 @@ use
 	futures           :: { StreamExt                         } ,
 	async_tungstenite :: { accept_async, tokio::TokioAdapter } ,
 	tokio             :: { net::{ TcpListener, TcpStream }   } ,
-	log               :: { *                                 } ,
+	tracing           :: { *                                 } ,
 	std               :: { env, net::SocketAddr              } ,
 };
 

--- a/examples/tokio_codec.rs
+++ b/examples/tokio_codec.rs
@@ -4,13 +4,12 @@
 //
 use
 {
+	tungstenite           :: { protocol::Role                   } ,
 	ws_stream_tungstenite :: { *                                } ,
 	futures               :: { StreamExt, SinkExt, future::join } ,
 	tokio_util::codec     :: { LinesCodec, Framed               } ,
 	futures_ringbuf       :: { Endpoint                         } ,
-
-	log :: { * } ,
-	tungstenite::{ protocol::Role } ,
+	tracing               :: { *                                } ,
 };
 
 
@@ -18,14 +17,6 @@ use
 //
 async fn main()
 {
-	flexi_logger::Logger
-
-		::try_with_str( "futures_ringbuf=info, tokio_codec=trace, tokio_util=trace, ws_stream_tungstenite=trace, tokio=trace" )
-		.expect( "flexi_logger")
-		.start()
-		.expect( "flexi_logger")
-	;
-
 	let (server_con, client_con) = Endpoint::pair( 64, 64 );
 
 	let server = async move

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,6 @@ pub use
 };
 
 
-
 mod import
 {
 	pub(crate) use
@@ -46,7 +45,7 @@ mod import
 		futures_sink      :: { Sink                                                                                         } ,
 		futures_io        :: { AsyncRead, AsyncWrite, AsyncBufRead                                                          } ,
 		futures_util      :: { FutureExt                                                                                    } ,
-		log               :: { error                                                                                        } ,
+		tracing           :: { error                                                                                        } ,
 		std               :: { io, io::{ IoSlice, IoSliceMut }, pin::Pin, fmt, borrow::Cow                                  } ,
 		std               :: { collections::VecDeque, sync::Arc, task::{ Context, Poll }                                    } ,
 		async_tungstenite :: { WebSocketStream as ATungSocket                                                               } ,
@@ -77,7 +76,7 @@ mod import
 		futures_ringbuf   :: { Endpoint                               } ,
 		futures           :: { future::{ join }                       } ,
 		tungstenite       :: { protocol::{ Role }                     } ,
-		log               :: { *                                      } ,
+		tracing           :: { *                                      } ,
 	};
 }
 

--- a/src/tung_websocket.rs
+++ b/src/tung_websocket.rs
@@ -37,7 +37,7 @@ bitflags!
 
 
 /// A wrapper around a WebSocket provided by tungstenite. This provides Stream/Sink Vec<u8> to
-/// simplify implementing AsyncRead/AsyncWrite on top of tokio-tungstenite.
+/// simplify implementing AsyncRead/AsyncWrite on top of async-tungstenite.
 //
 pub(crate) struct TungWebSocket<S>  where S: AsyncRead + AsyncWrite + Send + Unpin
 {
@@ -546,25 +546,26 @@ fn to_io_error( err: TungErr ) -> io::Error
 		TungErr::Capacity(string) => io::Error::new( io::ErrorKind::InvalidData, string ),
 
 
-		// This is dealt with by backpressure in the compat layer over tokio-tungstenite.
-		// We should never see this error.
+		// This can happen if we send a message bigger than the tungstenite `max_write_buffer_len`.
+		// However `WsStream` looks at the size of this buffer and only sends up to `max_write_buffer_len`
+		// bytes in one message.
 		//
-		TungErr::WriteBufferFull(_) |
+		TungErr::WriteBufferFull(_) => unreachable!( "TungErr::WriteBufferFull" ),
 
 		// These are handshake errors
 		//
-		TungErr::Url       (..) |
+		TungErr::Url(_) => unreachable!( "TungErr::Url" ),
 
 		// This is an error specific to Text Messages that we don't use
 		//
-		TungErr::Utf8 |
+		TungErr::Utf8 => unreachable!( "TungErr::Utf8" ),
 
 		// I'd rather have this match exhaustive, but tungstenite has a Tls variant that
 		// is only there if they have a feature enabled. Since we cannot check whether
 		// a feature is enabled on a dependency, we have to go for wildcard here.
 		// As of tungstenite 0.19 Http and HttpFormat are also behind a feature flag.
 		//
-		_ => unreachable!() ,
+		x => unreachable!( "unmatched tungstenite error: {x}" ),
 	}
 }
 

--- a/src/ws_stream.rs
+++ b/src/ws_stream.rs
@@ -3,12 +3,22 @@ use crate::{ import::*, tung_websocket::TungWebSocket, WsEvent, WsErr };
 
 /// Takes a [`WebSocketStream`](async_tungstenite::WebSocketStream) and implements futures 0.3 `AsyncRead`/`AsyncWrite`/`AsyncBufRead`.
 ///
+/// Will always create an entire Websocket message from every write. Tungstenite buffers messages up to
+/// `write_buffer_size` in their [`tungstenite::protocol::WebSocketConfig`]. If you want small messages to be sent out,
+/// either make sure this buffer is small enough or flush the writer.
+///
+/// On the other hand the `max_write_buffer_size` from tokio is the maximum size we can send in one go, otherwise
+/// _tungstenite_ returns an error. Our [`AsyncWrite`] implementation never sends data that exceeds this buffer or
+/// `max_message_size`.
+///
+/// However you still must respect the `max_message_size` of the receiving end.
+///
 /// ## Errors
 ///
 /// Errors returned directly are generally io errors from the underlying stream. Only fatal errors are returned in
 /// band, so consider them fatal and drop the WsStream object.
 ///
-/// Other errors are returned out of band through _pharos_:
+/// Other errors are returned out of band through [_pharos_](https://crates.io/crates/pharos):
 ///
 /// On reading, eg. `AsyncRead::poll_read`:
 /// - [`WsErr::Protocol`]: The remote made a websocket protocol violation. The connection will be closed
@@ -20,11 +30,7 @@ use crate::{ import::*, tung_websocket::TungWebSocket, WsEvent, WsErr };
 /// - [`WsErr::ReceivedText`]: This means the remote send a text message, which is not supported, so the connection will
 ///   be gracefully closed. You can just keep calling `poll_read` until `None` is returned.
 ///
-/// On writing, eg. `AsyncWrite::*` all errors are fatal. Note that if you get `io::ErrorKind::InvalidData`, it means you
-/// send data that exceeds the tungstenite Capacity. Eg. it leads to a message that exceeds the max message size in tungstenite.
-/// It's intended that _ws_stream_tungstenite_ protects from this by splitting the data in several messages, but for now
-/// there is no way to find out what the max message size is from the underlying WebSocketStream, so that will require
-/// changes in the API of _tungstenite_ and _async-tungstenite_, so that will be for a future release.
+/// On writing, eg. `AsyncWrite::*` all errors are fatal.
 ///
 /// When a Protocol error is encountered during writing, it indicates that either _ws_stream_tungstenite_ or _tungstenite_ have
 /// a bug so it will panic.
@@ -32,6 +38,7 @@ use crate::{ import::*, tung_websocket::TungWebSocket, WsEvent, WsErr };
 pub struct WsStream<S> where S: AsyncRead + AsyncWrite + Send + Unpin
 {
 	inner: IoStream< TungWebSocket<S>, Vec<u8> >,
+	buffer_size: usize,
 }
 
 
@@ -42,9 +49,13 @@ impl<S> WsStream<S> where S: AsyncRead + AsyncWrite + Send + Unpin
 	//
 	pub fn new( inner: ATungSocket<S> ) -> Self
 	{
+		let c           = inner.get_config();
+		let buffer_size = std::cmp::min( c.max_write_buffer_size, c.max_message_size.unwrap_or(usize::MAX) );
+
 		Self
 		{
-			inner : IoStream::new( TungWebSocket::new( inner ) ),
+			buffer_size,
+			inner      : IoStream::new( TungWebSocket::new( inner ) ),
 		}
 	}
 }
@@ -63,23 +74,54 @@ impl<S> fmt::Debug for WsStream<S> where S: AsyncRead + AsyncWrite + Send + Unpi
 
 impl<S> AsyncWrite for WsStream<S> where S: AsyncRead + AsyncWrite + Send + Unpin
 {
-	/// Will always flush the underlying socket. Will always create an entire Websocket message from every write,
-	/// so call with a sufficiently large buffer if you have performance problems. Don't call with a buffer larger
-	/// than the max message size accepted by the remote endpoint.
-	//
 	fn poll_write( mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8] ) -> Poll< io::Result<usize> >
 	{
-		AsyncWrite::poll_write( Pin::new( &mut self.inner ), cx, buf )
+		let buffer_size = std::cmp::min(self.buffer_size, buf.len());
+		AsyncWrite::poll_write( Pin::new( &mut self.inner ), cx, &buf[..buffer_size] )
 	}
 
 
-	/// Will always flush the underlying socket. Will always create an entire Websocket message from every write,
-	/// so call with a sufficiently large buffers if you have performance problems. Don't call with a buffer larger
-	/// than the max message size accepted by the remote endpoint.
-	//
 	fn poll_write_vectored( mut self: Pin<&mut Self>, cx: &mut Context<'_>, bufs: &[ IoSlice<'_> ] ) -> Poll< io::Result<usize> >
 	{
-		AsyncWrite::poll_write_vectored( Pin::new( &mut self.inner ), cx, bufs )
+		let mut take_size = 0;
+		let mut seen_size = 0;
+		let mut next = 1;
+
+		for (i, buf) in bufs.iter().enumerate()
+		{
+			let len = buf.len();
+			seen_size += len;
+
+			// If this buffer does not fit entirely
+			//
+			if take_size + len > self.buffer_size { break; }
+
+			take_size += len;
+			next  = i+1;
+		}
+
+		// TODO: scenarios to test:
+		// - 1 buffer, empty
+		// - 1 buffer, smaller than self.buffer_size
+		// - 1 buffer, too big
+		// - several buffers, some early ones are empty
+		// - several buffers, first one is smaller than self.buffer_size
+
+		// There is no data at all
+		//
+		if seen_size == 0 { return Poll::Ready(Ok(0)); }
+
+		// If the first non-empty buffer is too big, let poll_write take the right amount out of it.
+		//
+		if take_size == 0
+		{
+			return AsyncWrite::poll_write( self, cx, bufs[next-1].get(0..).expect("index 0 not to be out of bounds") );
+		}
+
+		// If we can fill from multiple buffers, we don't try to split any buffer, just take buffers as long as they
+		// fit entirely.
+		//
+		AsyncWrite::poll_write_vectored( Pin::new( &mut self.inner ), cx, &bufs[0..next] )
 	}
 
 

--- a/tests/buffer_size.rs
+++ b/tests/buffer_size.rs
@@ -1,0 +1,94 @@
+#![allow(unused_imports)]
+
+// Verify the correct error is returned when sending a text message.
+//
+use
+{
+	ws_stream_tungstenite :: { *                                                                                  } ,
+	std                   :: { future::Future                                                                     } ,
+	futures               :: { StreamExt, SinkExt, executor::block_on, future::join                               } ,
+	asynchronous_codec    :: { LinesCodec, Framed                                                                 } ,
+	async_tungstenite     :: { WebSocketStream                                                                    } ,
+	tungstenite           :: { protocol::{ WebSocketConfig, CloseFrame, frame::coding::CloseCode, Role }, Message } ,
+	pharos                :: { Observable, ObserveConfig                                                          } ,
+	assert_matches        :: { assert_matches                                                                     } ,
+	async_progress        :: { Progress                                                                           } ,
+	futures_ringbuf       :: { Endpoint                                                                           } ,
+	tracing               :: { *                                                                                  } ,
+};
+
+
+// Test tungstenite buffer implementation with async_tungstenite:
+// 1. fill up part of `write_buffer_size`
+// 2. send a second message. The combination of both messages exceeds `max_write_buffer_size`.
+// 3. verify that it gives proper backpressure and we don't get an error for exceeding the max buffer size.
+//
+#[ test ]
+//
+fn buffer_size()
+{
+	let (sc, cs) = Endpoint::pair( 50, 50 );
+
+	let server = server( sc );
+	let client = client( cs );
+
+	block_on( join( server, client ) );
+	info!( "end test" );
+}
+
+
+async fn server( sc: Endpoint )
+{
+	let conf = WebSocketConfig
+	{
+		write_buffer_size: 6,
+		max_write_buffer_size: 8,
+		..Default::default()
+	};
+
+	let mut tws = WebSocketStream::from_raw_socket( sc, Role::Server, Some(conf) ).await;
+	let msg = Message::Binary(Vec::from("hello".as_bytes()));
+
+	let writer = async
+	{
+		info!( "start sending first message" );
+
+		tws.send( msg.clone() ).await.expect( "Send first line" );
+		info!( "finished sending first message" );
+
+		tws.send( msg ).await.expect( "Send first line" );
+		info!( "finished sending second message" );
+
+		tws.close(None).await.expect("close sink");
+		trace!( "server: writer end" );
+	};
+
+	writer.await;
+
+	trace!( "server: drop websocket" );
+}
+
+
+
+async fn client( cs: Endpoint )
+{
+	let     conf = WebSocketConfig::default();
+	let mut ws   = WebSocketStream::from_raw_socket( cs, Role::Client, Some(conf) ).await;
+
+	info!( "wait for client_read" );
+
+	let test = ws.next().await.unwrap().unwrap();
+	assert_matches!( test, Message::Binary(x) if x == "hello".as_bytes() );
+
+	info!( "client: received first binary message" );
+
+	let test = ws.next().await.unwrap().unwrap();
+	assert_matches!( test, Message::Binary(x) if x == "hello".as_bytes() );
+
+	info!( "client: received second binary message" );
+
+	let close = ws.next().await;
+	assert_matches!( close, Some(Ok(Message::Close(None))));
+
+	trace!( "client: drop websocket" );
+}

--- a/tests/futures_codec.rs
+++ b/tests/futures_codec.rs
@@ -10,8 +10,7 @@ use
 	tokio                 :: { net::{ TcpListener }                                 } ,
 	async_tungstenite     :: { accept_async, tokio::{ connect_async, TokioAdapter } } ,
 	url                   :: { Url                                                  } ,
-
-	log :: { * } ,
+	tracing               :: { *                                                    } ,
 };
 
 

--- a/tests/futures_codec_partial.rs
+++ b/tests/futures_codec_partial.rs
@@ -10,8 +10,7 @@ use
 	tokio                 :: { net::{ TcpListener }                                 } ,
 	async_tungstenite     :: { accept_async, tokio::{ connect_async, TokioAdapter } } ,
 	url                   :: { Url                                                  } ,
-
-	log :: { * } ,
+	tracing               :: { *                                                    } ,
 };
 
 

--- a/tests/ping_pong.rs
+++ b/tests/ping_pong.rs
@@ -8,14 +8,13 @@
 //
 use
 {
-	ws_stream_tungstenite :: { *                                                      } ,
-	futures               :: { StreamExt, SinkExt, future::join                       } ,
-	asynchronous_codec    :: { LinesCodec, Framed                                     } ,
-	tokio                 :: { net::{ TcpListener }                                   } ,
-	async_tungstenite     :: { accept_async, tokio::{ connect_async, TokioAdapter }   } ,
-	url                   :: { Url                                                    } ,
-
-	log :: { * } ,
+	ws_stream_tungstenite :: { *                                                    } ,
+	futures               :: { StreamExt, SinkExt, future::join                     } ,
+	asynchronous_codec    :: { LinesCodec, Framed                                   } ,
+	tokio                 :: { net::{ TcpListener }                                 } ,
+	async_tungstenite     :: { accept_async, tokio::{ connect_async, TokioAdapter } } ,
+	url                   :: { Url                                                  } ,
+	tracing               :: { *                                                    } ,
 };
 
 

--- a/tests/ping_pong_async_std.rs
+++ b/tests/ping_pong_async_std.rs
@@ -14,8 +14,7 @@ use
 	async_std             :: { net::{ TcpListener }                   } ,
 	async_tungstenite     :: { accept_async, async_std::connect_async } ,
 	url                   :: { Url                                    } ,
-
-	log :: { * } ,
+	tracing               :: { *                                      } ,
 };
 
 

--- a/tests/protocol_error.rs
+++ b/tests/protocol_error.rs
@@ -10,8 +10,7 @@ use
 	url                   :: { Url                                                  } ,
 	pharos                :: { Observable, ObserveConfig                            } ,
 	tungstenite           :: { protocol::{ CloseFrame, frame::coding::CloseCode }   } ,
-
-	log :: { * } ,
+	tracing               :: { *                                                    } ,
 };
 
 

--- a/tests/send_text.rs
+++ b/tests/send_text.rs
@@ -2,16 +2,15 @@
 //
 use
 {
-	ws_stream_tungstenite :: { *                                                      } ,
-	futures               :: { StreamExt, SinkExt, future::join                       } ,
-	asynchronous_codec    :: { LinesCodec, Framed                                     } ,
-	tokio                 :: { net::{ TcpListener }                                   } ,
-	async_tungstenite     :: { accept_async, tokio::{ connect_async, TokioAdapter }   } ,
-	url                   :: { Url                                                    } ,
-	pharos                :: { Observable, ObserveConfig                              } ,
-	tungstenite           :: { protocol::{ CloseFrame, frame::coding::CloseCode }     } ,
-
-	log :: { * } ,
+	ws_stream_tungstenite :: { *                                                    } ,
+	futures               :: { StreamExt, SinkExt, future::join                     } ,
+	asynchronous_codec    :: { LinesCodec, Framed                                   } ,
+	tokio                 :: { net::{ TcpListener }                                 } ,
+	async_tungstenite     :: { accept_async, tokio::{ connect_async, TokioAdapter } } ,
+	url                   :: { Url                                                  } ,
+	pharos                :: { Observable, ObserveConfig                            } ,
+	tungstenite           :: { protocol::{ CloseFrame, frame::coding::CloseCode }   } ,
+	tracing               :: { *                                                    } ,
 };
 
 

--- a/tests/tokio_codec.rs
+++ b/tests/tokio_codec.rs
@@ -12,8 +12,7 @@ use
 	tokio                 :: { net::{ TcpListener }                                 } ,
 	async_tungstenite     :: { accept_async, tokio::{ connect_async, TokioAdapter } } ,
 	url                   :: { Url                                                  } ,
-
-	log :: { * } ,
+	tracing               :: { *                                                    } ,
 };
 
 
@@ -21,8 +20,6 @@ use
 //
 async fn tokio_codec()
 {
-	// flexi_logger::Logger::with_str( "tokio_util=trace, ws_stream_tungstenite=trace, tokio=warn" ).start().expect( "flexi_logger");
-
 	let server = async
 	{
 		let socket = TcpListener::bind( "127.0.0.1:3012" ).await.expect( "bind to port" );


### PR DESCRIPTION
Tungstenite 0.20 starts buffering messages and thus has a max buffer size. When sending more data in, it returns an error. This is a problem for us as this would be fatal. We don't want to send any more data in than the buffer allows.

TODO in follow up commit:
- tests
- documentation