### PR TITLE
Update tungstenite and async-tungstenite dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
   [Unreleased]: https://github.com/najamelan/ws_stream_tungstenite/compare/0.11.0...dev
 
+  - **BREAKING_CHANGE**: update async-tungstenite to 0.24
+  - **BREAKING_CHANGE**: update tungstenite to 0.21
+
 
 ## [0.11.0] - 2023-10-07
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rustc_version = "^0.4"
 [dependencies]
 [dependencies.async-tungstenite]
 default-features = false
-version = "^0.23"
+version = "^0.24"
 
 [dependencies.async_io_stream]
 default-features = false
@@ -53,7 +53,7 @@ version = "^0.1"
 
 [dependencies.tungstenite]
 default-features = false
-version = "^0.20"
+version = "^0.21"
 
 [dev-dependencies]
 assert_matches = "^1"
@@ -73,7 +73,7 @@ version = "^1"
 
 [dev-dependencies.async-tungstenite]
 features = ["tokio-runtime", "async-std-runtime"]
-version = "^0.23"
+version = "^0.24"
 
 [dev-dependencies.tokio]
 default-features = false

--- a/Cargo.yml
+++ b/Cargo.yml
@@ -69,9 +69,9 @@ dependencies:
   futures-sink      : { version: ^0.3 , default-features: false                 }
   futures-io        : { version: ^0.3 , default-features: false                 }
   futures-util      : { version: ^0.3 , default-features: false                 }
-  tungstenite       : { version: ^0.20, default-features: false                 }
+  tungstenite       : { version: ^0.21, default-features: false                 }
   pharos            : { version: ^0.5 , default-features: false                 }
-  async-tungstenite : { version: ^0.23, default-features: false                 }
+  async-tungstenite : { version: ^0.24, default-features: false                 }
   tokio             : { version: ^1   , default-features: false, optional: true }
   tracing           : { version: ^0.1 }
 
@@ -84,7 +84,7 @@ dependencies:
 dev-dependencies:
 
   async-std           : { version: ^1, features: [ attributes ] }
-  async-tungstenite   : { version: ^0.23, features: [ tokio-runtime, async-std-runtime ] }
+  async-tungstenite   : { version: ^0.24, features: [ tokio-runtime, async-std-runtime ] }
   assert_matches      : ^1
   async_progress      : ^0.2
   futures             : ^0.3


### PR DESCRIPTION
Updating these dependencies lets dependants use the latest versions.